### PR TITLE
Rename .feat.yml to feat.yaml

### DIFF
--- a/cmd/feat/main.go
+++ b/cmd/feat/main.go
@@ -88,9 +88,9 @@ func printUsage() {
 	fmt.Println("Usage: feat <command> [args]")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  init              Create a new .feat.yml manifest")
+	fmt.Println("  init              Create a new feat.yaml manifest")
 	fmt.Println("  list              Show feature tree")
-	fmt.Println("  parse             Parse .feat.yml and dump structure")
+	fmt.Println("  parse             Parse feat.yaml and dump structure")
 	fmt.Println("  split <parent> <name>  Create a new feature")
 	fmt.Println("  status            Show current feature context")
 	fmt.Println("  validate          Check manifest for issues")
@@ -99,7 +99,7 @@ func printUsage() {
 	fmt.Println("  help              Show this help message")
 	fmt.Println()
 	fmt.Println("Global flags:")
-	fmt.Println("  -f <path>         Path to manifest file (default: .feat.yml)")
+	fmt.Println("  -f <path>         Path to manifest file (default: feat.yaml)")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  feat init                    # Create new manifest")
@@ -113,7 +113,7 @@ func printUsage() {
 func runInit() error {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	var manifestPath string
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func runInit() error {
 func runList() error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	var manifestPath string
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func runSplit() error {
 	fs := flag.NewFlagSet("split", flag.ContinueOnError)
 	var manifestPath string
 	var createFiles bool
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	fs.BoolVar(&createFiles, "create-files", true, "Create empty files on disk")
 	if err := fs.Parse(os.Args[4:]); err != nil {
 		return err
@@ -218,7 +218,7 @@ func runSplit() error {
 func runStatus() error {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 	var manifestPath string
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func runStatus() error {
 func runValidate() error {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
 	var manifestPath string
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func runWork() error {
 
 	fs := flag.NewFlagSet("work", flag.ContinueOnError)
 	var manifestPath string
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	if err := fs.Parse(os.Args[3:]); err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func runWork() error {
 func runParse() error {
 	fs := flag.NewFlagSet("parse", flag.ContinueOnError)
 	var manifestPath string
-	fs.StringVar(&manifestPath, "f", ".feat.yml", "Path to manifest file")
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		return err
 	}
@@ -350,9 +350,9 @@ func resolveManifestPath(manifestPath string) (string, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Check if we're in the right directory
-			if _, err := os.Stat(".feat.yml"); err == nil && manifestPath == ".feat.yml" {
-				// They ran without -f but there's a .feat.yml here
-				abs, _ := filepath.Abs(".feat.yml")
+			if _, err := os.Stat("feat.yaml"); err == nil && manifestPath == "feat.yaml" {
+				// They ran without -f but there's a feat.yaml here
+				abs, _ := filepath.Abs("feat.yaml")
 				return abs, nil
 			}
 			return "", fmt.Errorf("manifest not found: %s\nRun 'feat init' to create one, or specify with -f", absPath)

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -25,7 +25,7 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	manifestPath := filepath.Join(tmpDir, ".feat.yml")
+	manifestPath := filepath.Join(tmpDir, "feat.yaml")
 	if err := m.Save(manifestPath); err != nil {
 		t.Fatalf("Failed to save manifest: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestLoadMissingFiles(t *testing.T) {
 		},
 	}
 
-	manifestPath := filepath.Join(tmpDir, ".feat.yml")
+	manifestPath := filepath.Join(tmpDir, "feat.yaml")
 	if err := m.Save(manifestPath); err != nil {
 		t.Fatalf("Failed to save manifest: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestLoadNotLeaf(t *testing.T) {
 		},
 	}
 
-	manifestPath := filepath.Join(tmpDir, ".feat.yml")
+	manifestPath := filepath.Join(tmpDir, "feat.yaml")
 	if err := m.Save(manifestPath); err != nil {
 		t.Fatalf("Failed to save manifest: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestLoadNotFound(t *testing.T) {
 		Features: map[string]manifest.Feature{},
 	}
 
-	manifestPath := filepath.Join(tmpDir, ".feat.yml")
+	manifestPath := filepath.Join(tmpDir, "feat.yaml")
 	if err := m.Save(manifestPath); err != nil {
 		t.Fatalf("Failed to save manifest: %v", err)
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,4 +1,4 @@
-// Package manifest handles parsing and serialization of .feat.yml files.
+// Package manifest handles parsing and serialization of feat.yaml files.
 package manifest
 
 import (
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Manifest represents the root .feat.yml file.
+// Manifest represents the root feat.yaml file.
 type Manifest struct {
 	// Features is a map of feature names to Feature nodes.
 	// The root level contains systems/subsystems (intermediate nodes)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -9,7 +9,7 @@ import (
 func TestLoad(t *testing.T) {
 	// Create temp manifest
 	tmpDir := t.TempDir()
-	manifestPath := filepath.Join(tmpDir, ".feat.yml")
+	manifestPath := filepath.Join(tmpDir, "feat.yaml")
 
 	content := `
 auth:
@@ -47,7 +47,7 @@ auth:
 }
 
 func TestLoadNotFound(t *testing.T) {
-	_, err := Load("/nonexistent/path/.feat.yml")
+	_, err := Load("/nonexistent/path/feat.yaml")
 	if err == nil {
 		t.Error("Expected error for non-existent file")
 	}
@@ -55,7 +55,7 @@ func TestLoadNotFound(t *testing.T) {
 
 func TestSave(t *testing.T) {
 	tmpDir := t.TempDir()
-	manifestPath := filepath.Join(tmpDir, ".feat.yml")
+	manifestPath := filepath.Join(tmpDir, "feat.yaml")
 
 	m := &Manifest{
 		Features: map[string]Feature{

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -25,7 +25,7 @@ func TestSetAndGetCurrent(t *testing.T) {
 	mgr := NewManager(tmpDir)
 
 	// Set current
-	if err := mgr.SetCurrent("auth/login", "/project/.feat.yml"); err != nil {
+	if err := mgr.SetCurrent("auth/login", "/project/feat.yaml"); err != nil {
 		t.Fatalf("SetCurrent failed: %v", err)
 	}
 
@@ -43,8 +43,8 @@ func TestSetAndGetCurrent(t *testing.T) {
 		t.Errorf("FeaturePath = %q, want %q", state.FeaturePath, "auth/login")
 	}
 
-	if state.ManifestPath != "/project/.feat.yml" {
-		t.Errorf("ManifestPath = %q, want %q", state.ManifestPath, "/project/.feat.yml")
+	if state.ManifestPath != "/project/feat.yaml" {
+		t.Errorf("ManifestPath = %q, want %q", state.ManifestPath, "/project/feat.yaml")
 	}
 
 	if state.Timestamp.IsZero() {
@@ -71,7 +71,7 @@ func TestClear(t *testing.T) {
 	mgr := NewManager(tmpDir)
 
 	// Set then clear
-	if err := mgr.SetCurrent("auth/login", "/project/.feat.yml"); err != nil {
+	if err := mgr.SetCurrent("auth/login", "/project/feat.yaml"); err != nil {
 		t.Fatalf("SetCurrent failed: %v", err)
 	}
 
@@ -121,9 +121,9 @@ func TestFormatState(t *testing.T) {
 			name: "full state",
 			state: &State{
 				FeaturePath:  "auth/login",
-				ManifestPath: "/project/.feat.yml",
+				ManifestPath: "/project/feat.yaml",
 			},
-			contains: []string{"auth/login", "/project/.feat.yml"},
+			contains: []string{"auth/login", "/project/feat.yaml"},
 		},
 	}
 


### PR DESCRIPTION
Closes #5

Changes the manifest file convention from `.feat.yml` to `feat.yaml`:

- Removes the dot prefix — the manifest is the project's front door, should be visible
- Uses `.yaml` extension — per YAML specification preference
- Updates all code references, test files, and documentation

This is a breaking change for existing projects using `.feat.yml`, but since this is pre-v1, now is the time to make this correction.