### PR TITLE
Add tree root structure to manifest schema

### DIFF
--- a/cmd/feat/main.go
+++ b/cmd/feat/main.go
@@ -160,8 +160,8 @@ func runList() error {
 		return fmt.Errorf("loading manifest: %w", err)
 	}
 
-	if len(m.Tree.Features) == 0 {
-		fmt.Println("No features defined in manifest.")
+	if len(m.Tree.Children) == 0 {
+		fmt.Println("No children defined in manifest.")
 		fmt.Println("Create one with: feat split \"\" <feature-name>")
 		return nil
 	}
@@ -375,33 +375,33 @@ func resolveManifestPath(manifestPath string) (string, error) {
 }
 
 func printManifest(m *manifest.Manifest, indent int) {
-	for name, feature := range m.Tree.Features {
-		printFeature(name, feature, indent)
+	for name, node := range m.Tree.Children {
+		printNode(name, node, indent)
 	}
 }
 
-func printFeature(name string, f manifest.Feature, indent int) {
+func printNode(name string, n manifest.Node, indent int) {
 	prefix := strings.Repeat("  ", indent)
 
-	if f.IsLeaf() {
+	if n.IsFeature() {
 		fmt.Printf("%s%s (feature)\n", prefix, name)
-		for _, file := range f.Files {
+		for _, file := range n.Files {
 			fmt.Printf("%s  - %s\n", prefix, file)
 		}
-		if len(f.Tests) > 0 {
-			fmt.Printf("%s  [tests: %v]\n", prefix, f.Tests)
+		if len(n.Tests) > 0 {
+			fmt.Printf("%s  [tests: %v]\n", prefix, n.Tests)
 		}
 	} else {
-		fmt.Printf("%s%s/\n", prefix, name)
-		if len(f.Files) > 0 {
-			fmt.Printf("%s  [files: %v]\n", prefix, f.Files)
+		fmt.Printf("%s%s/ (boundary)\n", prefix, name)
+		if len(n.Files) > 0 {
+			fmt.Printf("%s  [files: %v]\n", prefix, n.Files)
 		}
-		if len(f.Tests) > 0 {
-			fmt.Printf("%s  [tests: %v]\n", prefix, f.Tests)
+		if len(n.Tests) > 0 {
+			fmt.Printf("%s  [tests: %v]\n", prefix, n.Tests)
 		}
 	}
 
-	for childName, child := range f.Children {
-		printFeature(childName, child, indent+1)
+	for childName, child := range n.Children {
+		printNode(childName, child, indent+1)
 	}
 }

--- a/feat.yaml
+++ b/feat.yaml
@@ -4,7 +4,7 @@ tree:
     - go.mod
     - go.sum
     - justfile
-  features:
+  children:
     cli:
       files:
         - cmd/feat/main.go

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -14,8 +14,8 @@ type Result struct {
 	// FeaturePath is the full path to the feature (e.g., "auth/password-reset").
 	FeaturePath string
 
-	// Feature is the resolved feature node.
-	Feature *manifest.Feature
+	// Node is the resolved node.
+	Node *manifest.Node
 
 	// Files are the absolute paths to the feature's implementation files.
 	Files []string
@@ -48,30 +48,30 @@ func New(m *manifest.Manifest, manifestPath string) *Loader {
 
 // Load resolves a feature path and collects its files and ancestor files.
 func (l *Loader) Load(featurePath string) (*Result, error) {
-	feature, ancestors, err := l.manifest.GetFeature(featurePath)
+	node, ancestors, err := l.manifest.GetFeature(featurePath)
 	if err != nil {
 		return nil, fmt.Errorf("resolving feature: %w", err)
 	}
 
-	if feature == nil {
+	if node == nil {
 		return nil, fmt.Errorf("feature not found: %s", featurePath)
 	}
 
-	if !feature.IsLeaf() {
-		return nil, fmt.Errorf("'%s' is not a leaf feature (it has no files)", featurePath)
+	if !node.IsFeature() {
+		return nil, fmt.Errorf("'%s' is not a feature (it has children)", featurePath)
 	}
 
 	result := &Result{
 		FeaturePath:   featurePath,
-		Feature:       feature,
-		Files:         make([]string, 0, len(feature.Files)),
-		Tests:         make([]string, 0, len(feature.Tests)),
+		Node:          node,
+		Files:         make([]string, 0, len(node.Files)),
+		Tests:         make([]string, 0, len(node.Tests)),
 		AncestorFiles: make([]string, 0, len(ancestors)),
 		MissingFiles:  []string{},
 	}
 
 	// Resolve implementation file paths relative to manifest directory
-	for _, file := range feature.Files {
+	for _, file := range node.Files {
 		absPath := l.resolvePath(file)
 		result.Files = append(result.Files, absPath)
 
@@ -82,7 +82,7 @@ func (l *Loader) Load(featurePath string) (*Result, error) {
 	}
 
 	// Resolve test file paths
-	for _, file := range feature.Tests {
+	for _, file := range node.Tests {
 		absPath := l.resolvePath(file)
 		result.Tests = append(result.Tests, absPath)
 

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -15,11 +15,11 @@ func TestLoad(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test-project",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
 					Files: []string{"auth/interface.go", "auth/types.go"},
 					Tests: []string{"auth/interface_test.go"},
-					Children: map[string]manifest.Feature{
+					Children: map[string]manifest.Node{
 						"login": {
 							Files: []string{"auth/login/handler.go", "auth/login/types.go"},
 							Tests: []string{"auth/login/handler_test.go"},
@@ -91,7 +91,7 @@ func TestLoadMissingFiles(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
 					Files: []string{"auth/missing.go"},
 					Tests: []string{"auth/missing_test.go"},
@@ -122,10 +122,10 @@ func TestLoadNotLeaf(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
 					Files: []string{"auth/interface.go"},
-					Children: map[string]manifest.Feature{
+					Children: map[string]manifest.Node{
 						"login": {Files: []string{"auth/login.go"}},
 					},
 				},
@@ -141,7 +141,7 @@ func TestLoadNotLeaf(t *testing.T) {
 	l := New(m, manifestPath)
 	_, err := l.Load("auth")
 	if err == nil {
-		t.Error("Expected error for non-leaf feature")
+		t.Error("Expected error for boundary (non-feature)")
 	}
 }
 
@@ -151,7 +151,7 @@ func TestLoadNotFound(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name:     "test",
-			Features: map[string]manifest.Feature{},
+			Children: map[string]manifest.Node{},
 		},
 	}
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -22,59 +22,60 @@ type Tree struct {
 	// Files are files at the root level (e.g., go.mod, README.md).
 	Files []string `yaml:"files,omitempty"`
 
-	// Features are the top-level features.
-	Features map[string]Feature `yaml:"features,omitempty"`
+	// Children are the top-level nodes (boundaries or features).
+	Children map[string]Node `yaml:"children,omitempty"`
 }
 
-// Feature represents either an intermediate node (subsystem) or a leaf (actual feature).
-type Feature struct {
-	// Files are the implementation files for this feature.
-	// Both intermediate nodes and leaves can have files.
+// Node is the interface for all nodes in the tree.
+// A Node is either a Boundary (intermediate, has children) or a Feature (leaf).
+type Node struct {
+	// Files are the implementation files for this node.
+	// Both boundaries and features can have files.
 	Files []string `yaml:"files,omitempty"`
 
-	// Tests are the test files for this feature.
-	// Kept separate from Files to distinguish implementation from tests.
+	// Tests are the test files for this node.
+	// Only features have tests (boundaries don't have direct tests).
 	Tests []string `yaml:"tests,omitempty"`
 
-	// Children are nested features (subsystems).
-	// If Children is non-nil, this is an intermediate node.
-	// If Children is nil, this is a leaf (if it has content) or placeholder (if empty).
-	Children map[string]Feature `yaml:",inline"`
+	// Children are nested nodes.
+	// If Children is non-nil, this node is a Boundary (intermediate).
+	// If Children is nil, this node is a Feature (leaf).
+	Children map[string]Node `yaml:",inline"`
 }
 
-// IsLeaf returns true if this feature is a leaf node.
-// A leaf has content (files/tests) and no children.
-// Note: An empty feature (no files, no tests, no children) is a placeholder, not a leaf.
-func (f Feature) IsLeaf() bool {
-	if f.Children != nil {
-		return false // Has children → intermediate
+// IsFeature returns true if this node is a Feature (leaf).
+// A feature has content (files/tests) and no children.
+// Note: An empty node (no files, no tests, no children) is a placeholder boundary.
+func (n Node) IsFeature() bool {
+	if n.Children != nil {
+		return false // Has children → boundary
 	}
 	// No children - check if it has content
-	hasContent := len(f.Files) > 0 || len(f.Tests) > 0
+	hasContent := len(n.Files) > 0 || len(n.Tests) > 0
 	return hasContent
 }
 
-// IsIntermediate returns true if this feature is an intermediate node.
-// Intermediate nodes either:
+// IsBoundary returns true if this node is a Boundary (intermediate).
+// Boundaries either:
 //   - Have explicit children (non-nil Children map)
 //   - Are empty placeholders (no files, no tests, no children defined yet)
-func (f Feature) IsIntermediate() bool {
-	if f.Children != nil {
+func (n Node) IsBoundary() bool {
+	if n.Children != nil {
 		return true // Has explicit children
 	}
 	// No children - check if it's an empty placeholder
-	hasContent := len(f.Files) > 0 || len(f.Tests) > 0
-	return !hasContent // Empty = placeholder = intermediate
+	hasContent := len(n.Files) > 0 || len(n.Tests) > 0
+	return !hasContent // Empty = placeholder = boundary
 }
 
-// HasContent returns true if this feature has any files or tests.
-func (f Feature) HasContent() bool {
-	return len(f.Files) > 0 || len(f.Tests) > 0
+// HasContent returns true if this node has any files or tests.
+func (n Node) HasContent() bool {
+	return len(n.Files) > 0 || len(n.Tests) > 0
 }
 
 // AllFiles returns both implementation and test files.
-func (f Feature) AllFiles() []string {
-	return append(f.Files, f.Tests...)
+func (n Node) AllFiles() []string {
+	return append(n.Files, n.Tests...)
 }
 
 // Load reads a manifest from the given path.
@@ -113,51 +114,64 @@ func (m *Manifest) Save(path string) error {
 	return nil
 }
 
-// GetFeature retrieves a feature by its path (e.g., "auth/password-reset").
+// GetNode retrieves a node by its path (e.g., "auth/password-reset").
 // Returns nil if not found.
-func (m *Manifest) GetFeature(path string) (*Feature, []string, error) {
+func (m *Manifest) GetNode(path string) (*Node, []string, error) {
 	if path == "" {
-		return nil, nil, fmt.Errorf("empty feature path")
+		return nil, nil, fmt.Errorf("empty path")
 	}
 
 	parts := splitPath(path)
 	if len(parts) == 0 {
-		return nil, nil, fmt.Errorf("invalid feature path: %s", path)
+		return nil, nil, fmt.Errorf("invalid path: %s", path)
 	}
 
 	// Collect ancestor implementation files as we traverse
 	// Note: ancestor test files are NOT included (tests are feature-specific)
 	var ancestors []string
 
-	current := m.Tree.Features
-	var feature *Feature
+	current := m.Tree.Children
+	var node *Node
 
 	for i, part := range parts {
-		f, ok := current[part]
+		n, ok := current[part]
 		if !ok {
-			return nil, nil, fmt.Errorf("feature not found: %s", path)
+			return nil, nil, fmt.Errorf("node not found: %s", path)
 		}
 
-		// If this is the last part, we've found our feature
+		// If this is the last part, we've found our node
 		if i == len(parts)-1 {
-			feature = &f
+			node = &n
 			break
 		}
 
 		// Otherwise, this is a parent node - collect its implementation files (not tests)
-		ancestors = append(ancestors, f.Files...)
+		ancestors = append(ancestors, n.Files...)
 
 		// Descend into children
-		if f.Children == nil {
+		if n.Children == nil {
 			return nil, nil, fmt.Errorf("path continues but %s has no children", part)
 		}
-		current = f.Children
+		current = n.Children
 	}
 
-	return feature, ancestors, nil
+	return node, ancestors, nil
 }
 
-// splitPath splits a feature path like "auth/password-reset" into parts.
+// GetFeature is an alias for GetNode for backward compatibility.
+// It returns an error if the node is a boundary (not a feature).
+func (m *Manifest) GetFeature(path string) (*Node, []string, error) {
+	node, ancestors, err := m.GetNode(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if node != nil && node.IsBoundary() {
+		return nil, nil, fmt.Errorf("%s is a boundary, not a feature", path)
+	}
+	return node, ancestors, nil
+}
+
+// splitPath splits a path like "auth/password-reset" into parts.
 func splitPath(path string) []string {
 	var parts []string
 	var current string
@@ -185,27 +199,27 @@ func (m *Manifest) Validate() []string {
 		issues = append(issues, "manifest tree has no name")
 	}
 
-	if len(m.Tree.Features) == 0 {
-		issues = append(issues, "manifest has no features defined")
+	if len(m.Tree.Children) == 0 {
+		issues = append(issues, "manifest has no children defined")
 	}
 
-	for name, f := range m.Tree.Features {
-		issues = append(issues, validateFeature(name, f)...)
+	for name, n := range m.Tree.Children {
+		issues = append(issues, validateNode(name, n)...)
 	}
 
 	return issues
 }
 
-func validateFeature(name string, f Feature) []string {
+func validateNode(name string, n Node) []string {
 	var issues []string
 
-	// Note: Intermediate nodes CAN have files/tests. They're not just boundaries.
+	// Note: Boundaries CAN have files. They're not just containers.
 	// An auth subsystem might have auth/interface.go AND auth/login/ children.
 
 	// Validate children recursively
-	if f.Children != nil {
-		for childName, child := range f.Children {
-			issues = append(issues, validateFeature(name+"/"+childName, child)...)
+	if n.Children != nil {
+		for childName, child := range n.Children {
+			issues = append(issues, validateNode(name+"/"+childName, child)...)
 		}
 	}
 
@@ -217,7 +231,7 @@ func Init(path string, projectName string) error {
 	m := &Manifest{
 		Tree: Tree{
 			Name:     projectName,
-			Features: make(map[string]Feature),
+			Children: make(map[string]Node),
 		},
 	}
 	return m.Save(path)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -16,7 +16,7 @@ tree:
   name: my-project
   files:
     - root.go
-  features:
+  children:
     auth:
       files:
         - auth/interface.go
@@ -47,13 +47,13 @@ tree:
 		t.Errorf("Expected root files ['root.go'], got %v", m.Tree.Files)
 	}
 
-	if len(m.Tree.Features) != 1 {
-		t.Errorf("Expected 1 root feature, got %d", len(m.Tree.Features))
+	if len(m.Tree.Children) != 1 {
+		t.Errorf("Expected 1 root child, got %d", len(m.Tree.Children))
 	}
 
-	auth, ok := m.Tree.Features["auth"]
+	auth, ok := m.Tree.Children["auth"]
 	if !ok {
-		t.Fatal("Expected 'auth' feature")
+		t.Fatal("Expected 'auth' node")
 	}
 
 	if len(auth.Files) != 1 || auth.Files[0] != "auth/interface.go" {
@@ -83,11 +83,11 @@ func TestSave(t *testing.T) {
 	m := &Manifest{
 		Tree: Tree{
 			Name: "test-project",
-			Features: map[string]Feature{
+			Children: map[string]Node{
 				"auth": {
 					Files: []string{"auth/interface.go"},
 					Tests: []string{"auth/interface_test.go"},
-					Children: map[string]Feature{
+					Children: map[string]Node{
 						"login": {
 							Files: []string{"auth/login/handler.go"},
 							Tests: []string{"auth/login/handler_test.go"},
@@ -117,24 +117,24 @@ func TestSave(t *testing.T) {
 		t.Errorf("Expected name 'test-project', got %q", m2.Tree.Name)
 	}
 
-	if len(m2.Tree.Features) != 1 {
-		t.Errorf("Expected 1 feature after reload, got %d", len(m2.Tree.Features))
+	if len(m2.Tree.Children) != 1 {
+		t.Errorf("Expected 1 child after reload, got %d", len(m2.Tree.Children))
 	}
 
-	auth := m2.Tree.Features["auth"]
+	auth := m2.Tree.Children["auth"]
 	if len(auth.Tests) != 1 {
 		t.Errorf("Expected 1 test after reload, got %d", len(auth.Tests))
 	}
 }
 
-func TestGetFeature(t *testing.T) {
+func TestGetNode(t *testing.T) {
 	m := &Manifest{
 		Tree: Tree{
 			Name: "test",
-			Features: map[string]Feature{
+			Children: map[string]Node{
 				"auth": {
 					Files: []string{"auth/interface.go"},
-					Children: map[string]Feature{
+					Children: map[string]Node{
 						"login": {
 							Files: []string{"auth/login/handler.go"},
 						},
@@ -147,98 +147,98 @@ func TestGetFeature(t *testing.T) {
 	tests := []struct {
 		path            string
 		expectError     bool
-		expectLeaf      bool
+		expectFeature   bool
 		expectAncestors int
 	}{
 		{"auth/login", false, true, 1}, // 1 ancestor file: auth/interface.go
-		{"auth", false, false, 0},      // 0 ancestors (root level, not leaf)
+		{"auth", false, false, 0},      // 0 ancestors (root level, boundary)
 		{"nonexistent", true, false, 0},
 		{"auth/nonexistent", true, false, 0},
 		{"", true, false, 0},
 	}
 
 	for _, tt := range tests {
-		f, ancestors, err := m.GetFeature(tt.path)
+		n, ancestors, err := m.GetNode(tt.path)
 		if tt.expectError {
 			if err == nil {
-				t.Errorf("GetFeature(%q): expected error, got nil", tt.path)
+				t.Errorf("GetNode(%q): expected error, got nil", tt.path)
 			}
 			continue
 		}
 		if err != nil {
-			t.Errorf("GetFeature(%q): unexpected error: %v", tt.path, err)
+			t.Errorf("GetNode(%q): unexpected error: %v", tt.path, err)
 			continue
 		}
-		if f == nil {
-			t.Errorf("GetFeature(%q): expected feature, got nil", tt.path)
+		if n == nil {
+			t.Errorf("GetNode(%q): expected node, got nil", tt.path)
 			continue
 		}
-		if f.IsLeaf() != tt.expectLeaf {
-			t.Errorf("GetFeature(%q): IsLeaf() = %v, want %v", tt.path, f.IsLeaf(), tt.expectLeaf)
+		if n.IsFeature() != tt.expectFeature {
+			t.Errorf("GetNode(%q): IsFeature() = %v, want %v", tt.path, n.IsFeature(), tt.expectFeature)
 		}
 		if len(ancestors) != tt.expectAncestors {
-			t.Errorf("GetFeature(%q): len(ancestors) = %d, want %d", tt.path, len(ancestors), tt.expectAncestors)
+			t.Errorf("GetNode(%q): len(ancestors) = %d, want %d", tt.path, len(ancestors), tt.expectAncestors)
 		}
 	}
 }
 
-func TestFeatureIsLeaf(t *testing.T) {
+func TestNodeIsFeature(t *testing.T) {
 	tests := []struct {
-		f    Feature
+		n    Node
 		want bool
 	}{
-		{Feature{Files: []string{"a.go"}}, true},
-		{Feature{Tests: []string{"a_test.go"}}, true},
-		{Feature{Files: []string{"a.go"}, Tests: []string{"a_test.go"}}, true},
-		{Feature{Files: []string{}}, false},
-		{Feature{Children: map[string]Feature{}}, false},
-		{Feature{Files: []string{"a.go"}, Children: map[string]Feature{"child": {}}}, false},
+		{Node{Files: []string{"a.go"}}, true},
+		{Node{Tests: []string{"a_test.go"}}, true},
+		{Node{Files: []string{"a.go"}, Tests: []string{"a_test.go"}}, true},
+		{Node{Files: []string{}}, false}, // empty
+		{Node{Children: map[string]Node{}}, false},
+		{Node{Files: []string{"a.go"}, Children: map[string]Node{"child": {}}}, false},
 	}
 
 	for _, tt := range tests {
-		got := tt.f.IsLeaf()
+		got := tt.n.IsFeature()
 		if got != tt.want {
-			t.Errorf("IsLeaf() = %v, want %v for %+v", got, tt.want, tt.f)
+			t.Errorf("IsFeature() = %v, want %v for %+v", got, tt.want, tt.n)
 		}
 	}
 }
 
-func TestFeatureIsIntermediate(t *testing.T) {
+func TestNodeIsBoundary(t *testing.T) {
 	tests := []struct {
-		f    Feature
+		n    Node
 		want bool
 	}{
-		// Has children → intermediate
-		{Feature{Children: map[string]Feature{"child": {}}}, true},
-		// Has files and children → intermediate
-		{Feature{Files: []string{"a.go"}, Children: map[string]Feature{"child": {}}}, true},
-		// Has files only → leaf
-		{Feature{Files: []string{"a.go"}}, false},
-		// Has tests only → leaf
-		{Feature{Tests: []string{"a_test.go"}}, false},
-		// Has both files and tests → leaf
-		{Feature{Files: []string{"a.go"}, Tests: []string{"a_test.go"}}, false},
-		// Empty subsystem → intermediate (boundary placeholder)
-		{Feature{}, true},
-		// Empty children map → intermediate
-		{Feature{Children: map[string]Feature{}}, true},
+		// Has children → boundary
+		{Node{Children: map[string]Node{"child": {}}}, true},
+		// Has files and children → boundary
+		{Node{Files: []string{"a.go"}, Children: map[string]Node{"child": {}}}, true},
+		// Has files only → feature
+		{Node{Files: []string{"a.go"}}, false},
+		// Has tests only → feature
+		{Node{Tests: []string{"a_test.go"}}, false},
+		// Has both files and tests → feature
+		{Node{Files: []string{"a.go"}, Tests: []string{"a_test.go"}}, false},
+		// Empty boundary → boundary (placeholder)
+		{Node{}, true},
+		// Empty children map → boundary
+		{Node{Children: map[string]Node{}}, true},
 	}
 
 	for _, tt := range tests {
-		got := tt.f.IsIntermediate()
+		got := tt.n.IsBoundary()
 		if got != tt.want {
-			t.Errorf("IsIntermediate() = %v, want %v for %+v", got, tt.want, tt.f)
+			t.Errorf("IsBoundary() = %v, want %v for %+v", got, tt.want, tt.n)
 		}
 	}
 }
 
-func TestFeatureAllFiles(t *testing.T) {
-	f := Feature{
+func TestNodeAllFiles(t *testing.T) {
+	n := Node{
 		Files: []string{"a.go", "b.go"},
 		Tests: []string{"a_test.go"},
 	}
 
-	all := f.AllFiles()
+	all := n.AllFiles()
 	if len(all) != 3 {
 		t.Errorf("Expected 3 files, got %d: %v", len(all), all)
 	}
@@ -252,28 +252,28 @@ func TestValidate(t *testing.T) {
 	}{
 		{
 			name:   "empty manifest",
-			m:      Manifest{Tree: Tree{Name: "", Features: map[string]Feature{}}},
-			issues: 2, // no name, no features
+			m:      Manifest{Tree: Tree{Name: "", Children: map[string]Node{}}},
+			issues: 2, // no name, no children
 		},
 		{
 			name: "missing name",
 			m: Manifest{
 				Tree: Tree{
 					Name:     "",
-					Features: map[string]Feature{"auth": {Files: []string{"auth.go"}}},
+					Children: map[string]Node{"auth": {Files: []string{"auth.go"}}},
 				},
 			},
 			issues: 1,
 		},
 		{
-			name: "valid feature tree",
+			name: "valid tree",
 			m: Manifest{
 				Tree: Tree{
 					Name: "my-project",
-					Features: map[string]Feature{
+					Children: map[string]Node{
 						"auth": {
 							Files: []string{"auth/interface.go"},
-							Children: map[string]Feature{
+							Children: map[string]Node{
 								"login": {Files: []string{"auth/login.go"}}},
 						},
 					},
@@ -282,21 +282,21 @@ func TestValidate(t *testing.T) {
 			issues: 0,
 		},
 		{
-			name: "valid leaf with tests",
+			name: "valid feature with tests",
 			m: Manifest{
 				Tree: Tree{
 					Name:     "my-project",
-					Features: map[string]Feature{"auth": {Files: []string{"auth.go"}, Tests: []string{"auth_test.go"}}},
+					Children: map[string]Node{"auth": {Files: []string{"auth.go"}, Tests: []string{"auth_test.go"}}},
 				},
 			},
 			issues: 0,
 		},
 		{
-			name: "valid empty subsystem",
+			name: "valid empty boundary",
 			m: Manifest{
 				Tree: Tree{
 					Name:     "my-project",
-					Features: map[string]Feature{"payments": {}},
+					Children: map[string]Node{"payments": {}},
 				},
 			},
 			issues: 0,

--- a/internal/split/split.go
+++ b/internal/split/split.go
@@ -12,11 +12,11 @@ import (
 
 // Options configures the split operation.
 type Options struct {
-	// ParentPath is the path to the parent feature (e.g., "auth" or "auth/password-reset").
-	// Use empty string for root-level features.
+	// ParentPath is the path to the parent node (e.g., "auth" or "auth/password-reset").
+	// Use empty string for root-level nodes.
 	ParentPath string
 
-	// NewName is the name for the new feature (e.g., "confirmation").
+	// NewName is the name for the new node (e.g., "confirmation").
 	NewName string
 
 	// CreateFiles if true, creates empty files on disk.
@@ -28,8 +28,8 @@ type Options struct {
 
 // Result contains the outcome of a split operation.
 type Result struct {
-	// NewFeaturePath is the full path to the created feature.
-	NewFeaturePath string
+	// NewPath is the full path to the created node.
+	NewPath string
 
 	// FilesCreated are the files that were created on disk (if any).
 	FilesCreated []string
@@ -38,13 +38,13 @@ type Result struct {
 	ManifestUpdated bool
 }
 
-// Split creates a new feature under the given parent path.
+// Split creates a new node under the given parent path.
 func Split(m *manifest.Manifest, opts Options) (*Result, error) {
 	if opts.NewName == "" {
-		return nil, fmt.Errorf("new feature name cannot be empty")
+		return nil, fmt.Errorf("new name cannot be empty")
 	}
 	if strings.Contains(opts.NewName, "/") {
-		return nil, fmt.Errorf("new feature name cannot contain '/': %s", opts.NewName)
+		return nil, fmt.Errorf("new name cannot contain '/': %s", opts.NewName)
 	}
 
 	result := &Result{
@@ -52,18 +52,18 @@ func Split(m *manifest.Manifest, opts Options) (*Result, error) {
 	}
 
 	// Determine the full path and get the parent map
-	var parentMap map[string]manifest.Feature
-	var newFeaturePath string
+	var parentMap map[string]manifest.Node
+	var newPath string
 
 	if opts.ParentPath == "" {
-		// Root-level feature
-		if m.Tree.Features == nil {
-			m.Tree.Features = make(map[string]manifest.Feature)
+		// Root-level node
+		if m.Tree.Children == nil {
+			m.Tree.Children = make(map[string]manifest.Node)
 		}
-		parentMap = m.Tree.Features
-		newFeaturePath = opts.NewName
+		parentMap = m.Tree.Children
+		newPath = opts.NewName
 	} else {
-		// Nested feature
+		// Nested node
 		parts := splitPath(opts.ParentPath)
 		if len(parts) == 0 {
 			return nil, fmt.Errorf("invalid parent path: %s", opts.ParentPath)
@@ -75,29 +75,29 @@ func Split(m *manifest.Manifest, opts Options) (*Result, error) {
 		if err != nil {
 			return nil, err
 		}
-		newFeaturePath = opts.ParentPath + "/" + opts.NewName
+		newPath = opts.ParentPath + "/" + opts.NewName
 	}
 
-	result.NewFeaturePath = newFeaturePath
+	result.NewPath = newPath
 
-	// Check if feature already exists
+	// Check if node already exists
 	if _, exists := parentMap[opts.NewName]; exists {
-		return nil, fmt.Errorf("feature already exists: %s", newFeaturePath)
+		return nil, fmt.Errorf("node already exists: %s", newPath)
 	}
 
-	// Create the new feature (leaf with empty files list)
-	newFeature := manifest.Feature{
+	// Create the new node (feature with empty files list)
+	newNode := manifest.Node{
 		Files: []string{},
 	}
 
 	// Add to parent's children
-	parentMap[opts.NewName] = newFeature
+	parentMap[opts.NewName] = newNode
 
 	// Create files on disk if requested
 	if opts.CreateFiles {
-		files, err := createFeatureFiles(opts.ManifestDir, newFeaturePath, opts.NewName)
+		files, err := createNodeFiles(opts.ManifestDir, newPath, opts.NewName)
 		if err != nil {
-			return nil, fmt.Errorf("creating feature files: %w", err)
+			return nil, fmt.Errorf("creating node files: %w", err)
 		}
 		result.FilesCreated = files
 	}
@@ -106,68 +106,68 @@ func Split(m *manifest.Manifest, opts Options) (*Result, error) {
 	return result, nil
 }
 
-// navigateToParent navigates to the parent feature's Children map.
+// navigateToParent navigates to the parent node's Children map.
 // Creates intermediate nodes if they don't exist.
-func navigateToParent(m *manifest.Manifest, parts []string) (map[string]manifest.Feature, error) {
-	if m.Tree.Features == nil {
-		m.Tree.Features = make(map[string]manifest.Feature)
+func navigateToParent(m *manifest.Manifest, parts []string) (map[string]manifest.Node, error) {
+	if m.Tree.Children == nil {
+		m.Tree.Children = make(map[string]manifest.Node)
 	}
 
-	current := m.Tree.Features
+	current := m.Tree.Children
 
 	for i, part := range parts {
-		f, exists := current[part]
+		n, exists := current[part]
 		if !exists {
-			// Create intermediate node
-			f = manifest.Feature{
-				Children: make(map[string]manifest.Feature),
+			// Create intermediate boundary node
+			n = manifest.Node{
+				Children: make(map[string]manifest.Node),
 			}
-			current[part] = f
+			current[part] = n
 		}
 
-		// If this is a leaf, we can't add children
-		if f.IsLeaf() {
-			return nil, fmt.Errorf("cannot add children to leaf feature: %s", strings.Join(parts[:i+1], "/"))
+		// If this is a feature (leaf), we can't add children
+		if n.IsFeature() {
+			return nil, fmt.Errorf("cannot add children to feature: %s", strings.Join(parts[:i+1], "/"))
 		}
 
 		// If this is the last part, return its Children map
 		if i == len(parts)-1 {
-			if f.Children == nil {
-				f.Children = make(map[string]manifest.Feature)
-				current[part] = f
+			if n.Children == nil {
+				n.Children = make(map[string]manifest.Node)
+				current[part] = n
 			}
-			return f.Children, nil
+			return n.Children, nil
 		}
 
 		// Descend into children
-		if f.Children == nil {
-			f.Children = make(map[string]manifest.Feature)
-			current[part] = f
+		if n.Children == nil {
+			n.Children = make(map[string]manifest.Node)
+			current[part] = n
 		}
-		current = f.Children
+		current = n.Children
 	}
 
 	return current, nil
 }
 
-// createFeatureFiles creates empty files for a new feature.
-func createFeatureFiles(manifestDir, featurePath, featureName string) ([]string, error) {
+// createNodeFiles creates empty files for a new node.
+func createNodeFiles(manifestDir, nodePath, nodeName string) ([]string, error) {
 	// Create directory structure
-	dirPath := filepath.Join(manifestDir, featurePath)
+	dirPath := filepath.Join(manifestDir, nodePath)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return nil, fmt.Errorf("creating directory %s: %w", dirPath, err)
 	}
 
 	// Create a placeholder file
 	placeholder := filepath.Join(dirPath, ".feat")
-	if err := os.WriteFile(placeholder, []byte("# "+featureName+" feature\n"), 0644); err != nil {
+	if err := os.WriteFile(placeholder, []byte("# "+nodeName+" feature\n"), 0644); err != nil {
 		return nil, fmt.Errorf("creating placeholder file: %w", err)
 	}
 
 	return []string{placeholder}, nil
 }
 
-// splitPath splits a feature path into parts.
+// splitPath splits a path into parts.
 func splitPath(path string) []string {
 	var parts []string
 	for _, p := range strings.Split(path, "/") {
@@ -181,7 +181,7 @@ func splitPath(path string) []string {
 // FormatResult returns a human-readable string representation of the result.
 func FormatResult(r *Result) string {
 	var output string
-	output += fmt.Sprintf("Created feature: %s\n", r.NewFeaturePath)
+	output += fmt.Sprintf("Created node: %s\n", r.NewPath)
 
 	if len(r.FilesCreated) > 0 {
 		output += fmt.Sprintf("Files created: %d\n", len(r.FilesCreated))

--- a/internal/split/split_test.go
+++ b/internal/split/split_test.go
@@ -11,13 +11,13 @@ import (
 func TestSplit(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Intermediate node: has children, no files
+	// Boundary node: has children, no files
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
-					Children: map[string]manifest.Feature{},
+					Children: map[string]manifest.Node{},
 				},
 			},
 		},
@@ -35,12 +35,12 @@ func TestSplit(t *testing.T) {
 		t.Fatalf("Split failed: %v", err)
 	}
 
-	if result.NewFeaturePath != "auth/logout" {
-		t.Errorf("NewFeaturePath = %q, want %q", result.NewFeaturePath, "auth/logout")
+	if result.NewPath != "auth/logout" {
+		t.Errorf("NewPath = %q, want %q", result.NewPath, "auth/logout")
 	}
 
-	// Verify feature was added
-	auth := m.Tree.Features["auth"]
+	// Verify node was added
+	auth := m.Tree.Children["auth"]
 	if _, ok := auth.Children["logout"]; !ok {
 		t.Error("Expected 'logout' to be added to auth children")
 	}
@@ -52,7 +52,7 @@ func TestSplitRootLevel(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name:     "test",
-			Features: map[string]manifest.Feature{},
+			Children: map[string]manifest.Node{},
 		},
 	}
 
@@ -68,11 +68,11 @@ func TestSplitRootLevel(t *testing.T) {
 		t.Fatalf("Split failed: %v", err)
 	}
 
-	if result.NewFeaturePath != "payments" {
-		t.Errorf("NewFeaturePath = %q, want %q", result.NewFeaturePath, "payments")
+	if result.NewPath != "payments" {
+		t.Errorf("NewPath = %q, want %q", result.NewPath, "payments")
 	}
 
-	if _, ok := m.Tree.Features["payments"]; !ok {
+	if _, ok := m.Tree.Children["payments"]; !ok {
 		t.Error("Expected 'payments' to be added to root")
 	}
 }
@@ -83,9 +83,9 @@ func TestSplitDuplicate(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
-					Children: map[string]manifest.Feature{
+					Children: map[string]manifest.Node{
 						"login": {Files: []string{"auth/login.go"}},
 					},
 				},
@@ -102,18 +102,18 @@ func TestSplitDuplicate(t *testing.T) {
 
 	_, err := Split(m, opts)
 	if err == nil {
-		t.Error("Expected error for duplicate feature")
+		t.Error("Expected error for duplicate node")
 	}
 }
 
-func TestSplitLeafParent(t *testing.T) {
+func TestSplitFeatureParent(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Leaf node: has files, no children
+	// Feature node: has files, no children
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
 					Files: []string{"auth.go"},
 				},
@@ -130,7 +130,7 @@ func TestSplitLeafParent(t *testing.T) {
 
 	_, err := Split(m, opts)
 	if err == nil {
-		t.Error("Expected error when splitting leaf feature")
+		t.Error("Expected error when splitting feature (leaf)")
 	}
 }
 
@@ -140,7 +140,7 @@ func TestSplitEmptyName(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name:     "test",
-			Features: map[string]manifest.Feature{},
+			Children: map[string]manifest.Node{},
 		},
 	}
 
@@ -163,7 +163,7 @@ func TestSplitWithSlash(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name:     "test",
-			Features: map[string]manifest.Feature{},
+			Children: map[string]manifest.Node{},
 		},
 	}
 
@@ -186,8 +186,8 @@ func TestSplitCreateFiles(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "test",
-			Features: map[string]manifest.Feature{
-				"auth": {Children: map[string]manifest.Feature{}},
+			Children: map[string]manifest.Node{
+				"auth": {Children: map[string]manifest.Node{}},
 			},
 		},
 	}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -23,22 +23,22 @@ func NewPrinter() *Printer {
 	}
 }
 
-// Print outputs the feature tree in a readable format.
+// Print outputs the tree in a readable format.
 // Format:
 //   auth/
-//     password-reset
-//     email-verification
+//     password-reset (feature)
+//     email-verification (feature)
 func (p *Printer) Print(m *manifest.Manifest) string {
 	var b strings.Builder
-	p.printFeatures(m.Tree.Features, 0, &b)
+	p.printChildren(m.Tree.Children, 0, &b)
 	return b.String()
 }
 
-// printFeatures recursively prints features in sorted order.
-func (p *Printer) printFeatures(features map[string]manifest.Feature, depth int, b *strings.Builder) {
+// printChildren recursively prints nodes in sorted order.
+func (p *Printer) printChildren(children map[string]manifest.Node, depth int, b *strings.Builder) {
 	// Sort keys for consistent output
-	names := make([]string, 0, len(features))
-	for name := range features {
+	names := make([]string, 0, len(children))
+	for name := range children {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -46,22 +46,22 @@ func (p *Printer) printFeatures(features map[string]manifest.Feature, depth int,
 	indent := strings.Repeat(p.IndentString, depth)
 
 	for _, name := range names {
-		feature := features[name]
-		p.printFeature(name, feature, indent, depth, b)
+		node := children[name]
+		p.printNode(name, node, indent, depth, b)
 	}
 }
 
-// printFeature prints a single feature node.
-func (p *Printer) printFeature(name string, f manifest.Feature, indent string, depth int, b *strings.Builder) {
-	if f.IsLeaf() {
-		// Leaf feature: just print the name
-		fmt.Fprintf(b, "%s%s\n", indent, name)
+// printNode prints a single node.
+func (p *Printer) printNode(name string, n manifest.Node, indent string, depth int, b *strings.Builder) {
+	if n.IsFeature() {
+		// Feature (leaf): print the name with (feature)
+		fmt.Fprintf(b, "%s%s (feature)\n", indent, name)
 	} else {
-		// Intermediate node: print name with trailing slash
+		// Boundary (intermediate): print name with trailing slash
 		fmt.Fprintf(b, "%s%s/\n", indent, name)
 		// Recurse into children
-		if len(f.Children) > 0 {
-			p.printFeatures(f.Children, depth+1, b)
+		if len(n.Children) > 0 {
+			p.printChildren(n.Children, depth+1, b)
 		}
 	}
 }
@@ -69,20 +69,20 @@ func (p *Printer) printFeature(name string, f manifest.Feature, indent string, d
 // ListPaths returns a simple list of all feature paths (for machine-readable output).
 func ListPaths(m *manifest.Manifest) []string {
 	var paths []string
-	collectPaths(m.Tree.Features, "", &paths)
+	collectPaths(m.Tree.Children, "", &paths)
 	return paths
 }
 
 // collectPaths recursively collects all feature paths.
-func collectPaths(features map[string]manifest.Feature, prefix string, paths *[]string) {
-	names := make([]string, 0, len(features))
-	for name := range features {
+func collectPaths(children map[string]manifest.Node, prefix string, paths *[]string) {
+	names := make([]string, 0, len(children))
+	for name := range children {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	for _, name := range names {
-		feature := features[name]
+		node := children[name]
 		var path string
 		if prefix == "" {
 			path = name
@@ -90,16 +90,16 @@ func collectPaths(features map[string]manifest.Feature, prefix string, paths *[]
 			path = prefix + "/" + name
 		}
 
-		if feature.IsLeaf() {
+		if node.IsFeature() {
 			*paths = append(*paths, path)
 		} else {
-			// Intermediate nodes with files can be valid targets
-			if len(feature.Files) > 0 {
+			// Boundaries with files can be valid targets
+			if len(node.Files) > 0 {
 				*paths = append(*paths, path+"/")
 			}
 			// Recurse into children
-			if len(feature.Children) > 0 {
-				collectPaths(feature.Children, path, paths)
+			if len(node.Children) > 0 {
+				collectPaths(node.Children, path, paths)
 			}
 		}
 	}

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -11,11 +11,11 @@ func TestPrint(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "my-project",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
 					Files: []string{"auth/interface.go"},
 					Tests: []string{"auth/interface_test.go"},
-					Children: map[string]manifest.Feature{
+					Children: map[string]manifest.Node{
 						"login": {
 							Files: []string{"auth/login.go"},
 							Tests: []string{"auth/login_test.go"},
@@ -36,7 +36,7 @@ func TestPrint(t *testing.T) {
 	printer := NewPrinter()
 	output := printer.Print(m)
 
-	// Check that output contains expected features
+	// Check that output contains expected nodes
 	if !strings.Contains(output, "auth/") {
 		t.Error("Expected output to contain 'auth/'")
 	}
@@ -64,7 +64,7 @@ func TestPrintEmpty(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name:     "my-project",
-			Features: map[string]manifest.Feature{},
+			Children: map[string]manifest.Node{},
 		},
 	}
 
@@ -80,10 +80,10 @@ func TestListPaths(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name: "my-project",
-			Features: map[string]manifest.Feature{
+			Children: map[string]manifest.Node{
 				"auth": {
 					Files: []string{"auth/interface.go"},
-					Children: map[string]manifest.Feature{
+					Children: map[string]manifest.Node{
 						"login": {Files: []string{"auth/login.go"}},
 					},
 				},
@@ -96,7 +96,7 @@ func TestListPaths(t *testing.T) {
 
 	paths := ListPaths(m)
 
-	// Should include: auth/ (intermediate with files), auth/login (leaf), payments (leaf)
+	// Should include: auth/ (boundary with files), auth/login (feature), payments (feature)
 	if len(paths) != 3 {
 		t.Errorf("Expected 3 paths, got %d: %v", len(paths), paths)
 	}
@@ -138,7 +138,7 @@ func TestListPathsEmpty(t *testing.T) {
 	m := &manifest.Manifest{
 		Tree: manifest.Tree{
 			Name:     "my-project",
-			Features: map[string]manifest.Feature{},
+			Children: map[string]manifest.Node{},
 		},
 	}
 


### PR DESCRIPTION
Fixes #7

Changes:
- Added Tree struct with Name, Files, and Features fields
- Changed Manifest to wrap features under Tree
- Renamed Feature.Children to Feature.Features for consistency
- Updated manifest.Load() and Save() for new structure
- Updated Init() to accept project name
- Updated all tests and example .feat.yml

Note: This builds on #14 and should be merged after #15.