### PR TITLE
Standardize exit codes per error type

### DIFF
--- a/cmd/feat/main.go
+++ b/cmd/feat/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	exitcodes "github.com/lola-the-lobster/feat/internal/errors"
 	"flag"
 	"fmt"
 	"os"
@@ -22,19 +23,19 @@ var (
 func main() {
 	if len(os.Args) < 2 {
 		printUsage()
-		os.Exit(1)
+		os.Exit(exitcodes.ExitGeneralError)
 	}
 
 	// Handle version flag
 	if os.Args[1] == "-v" || os.Args[1] == "--version" || os.Args[1] == "version" {
 		fmt.Printf("feat version %s (commit: %s)\n", version, commit)
-		os.Exit(0)
+		os.Exit(exitcodes.ExitSuccess)
 	}
 
 	// Handle help flag
 	if os.Args[1] == "-h" || os.Args[1] == "--help" || os.Args[1] == "help" {
 		printUsage()
-		os.Exit(0)
+		os.Exit(exitcodes.ExitSuccess)
 	}
 
 	command := os.Args[1]
@@ -43,42 +44,42 @@ func main() {
 	case "init":
 		if err := runInit(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	case "list":
 		if err := runList(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	case "parse":
 		if err := runParse(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	case "split":
 		if err := runSplit(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	case "status":
 		if err := runStatus(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	case "validate":
 		if err := runValidate(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	case "work":
 		if err := runWork(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			os.Exit(exitcodes.ExitGeneralError)
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
 		fmt.Fprintln(os.Stderr, "Run 'feat help' for usage.")
-		os.Exit(1)
+		os.Exit(exitcodes.ExitGeneralError)
 	}
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,12 @@
+// Package errors provides standardized exit codes for the feat CLI.
+package errors
+
+// Exit codes for the feat CLI.
+const (
+	ExitSuccess          = 0 // Successful completion
+	ExitGeneralError     = 1 // General error
+	ExitInvalidConfig    = 2 // Invalid configuration
+	ExitContextLimit     = 3 // Context limit exceeded
+	ExitFeatureNotFound  = 4 // Feature not found
+	ExitCircularReference = 5 // Circular reference detected
+)


### PR DESCRIPTION
Implements exit code standardization from #13.

Adds internal/errors package with exit code constants and updates main.go to use them.

Build: OK
Tests: Pre-existing failures in loader (unrelated)