### PR TITLE
feat: Add 'add' command for adding files to existing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ config:
 - `feat list` — Show feature tree
 - `feat work <feature>` — Load a feature's context
 - `feat split <parent> <name>` — Create a new feature
+- `feat add <feature> <file>` — Add a file to an existing feature
 - `feat status` — Show current feature context
 - `feat transition <step>` — Update feature workflow state
 - `feat validate` — Check manifest for issues
@@ -444,6 +445,9 @@ feat split "" auth
 feat split auth login
 
 # Work on a feature
+
+# Add files to a feature
+feat add auth/login auth/login_test.go
 feat work auth/login
 
 # Check status

--- a/README.md
+++ b/README.md
@@ -125,6 +125,303 @@ feat work <feature-id>
 
 This loads the feature's context, including its files and ancestor context.
 
+## Configuration Reference
+
+The `feat.yaml` file (or `.feat.yml`) is the single source of truth for your project's feature hierarchy. This section provides a complete reference for all configuration options.
+
+### File Structure
+
+```yaml
+config:
+  max_files: 3
+  workflow: [scaffold, fix, build, test, done]
+tree:
+  name: my-project
+  files: [go.mod, README.md]
+  children:
+    # Features and boundaries defined here
+```
+
+### Config Section
+
+The `config` section controls global behavior:
+
+#### `max_files` (integer)
+Maximum number of files to load when working on a feature. This includes the feature's own files plus ancestor files from parent boundaries.
+
+- **Default:** 3
+- **Purpose:** Prevents context overflow when agentic tools load feature context
+- **Behavior:** Files are collected from the current feature up through each parent boundary
+
+Example:
+```yaml
+config:
+  max_files: 5  # Allow more files for larger features
+```
+
+#### `workflow` (array of strings)
+Defines the steps a feature progresses through. Used by `feat transition` to track work state.
+
+- **Default:** `[scaffold, fix, build, test, done]`
+- **Purpose:** Standardizes feature lifecycle across your project
+- **Customization:** Use any steps that match your process
+
+Example:
+```yaml
+config:
+  workflow: [draft, review, implement, verify, complete]
+```
+
+### Tree Section
+
+The `tree` section defines your project's feature hierarchy:
+
+#### `name` (string)
+Project identifier. Used in output and logging.
+
+```yaml
+tree:
+  name: my-api-service
+```
+
+#### `files` (array of strings)
+Root-level files always included when loading any feature. Use for project-wide configuration and documentation.
+
+```yaml
+tree:
+  files: [go.mod, go.sum, README.md, Makefile]
+```
+
+#### `children` (map)
+Feature hierarchy. Keys are feature IDs, values are node definitions.
+
+```yaml
+tree:
+  children:
+    auth:
+      files: [auth/interface.go]
+      children:
+        login:
+          files: [auth/login.go]
+          tests: [auth/login_test.go]
+```
+
+### Node Types
+
+`feat` distinguishes between two node types:
+
+#### Boundary Nodes
+Group related features. Have children, no direct files/tests.
+
+Characteristics:
+- Has `children` map
+- No `files` or `tests` arrays
+- Serves as namespace/interface boundary
+- Files listed in a boundary define the interface for its children
+
+Example:
+```yaml
+auth:                      # Boundary
+  files: [auth/interface.go]
+  children:
+    login: {}              # Features inside
+```
+
+#### Feature Nodes
+Leaf nodes representing actual work. Have files/tests, no children.
+
+Characteristics:
+- Has `files` and/or `tests` arrays
+- No `children` map
+- Represents implementable unit of work
+- Full path forms the feature ID (e.g., `auth/login`)
+
+Example:
+```yaml
+login:                     # Feature
+  files: [auth/login.go]
+  tests: [auth/login_test.go]
+```
+
+### Node Fields
+
+All nodes (boundaries and features) support these fields:
+
+#### `files` (array of strings)
+Implementation files for this node. For boundaries, these define the interface contract. For features, these are the files to edit.
+
+```yaml
+files: [auth/login.go, auth/session.go]
+```
+
+#### `tests` (array of strings)
+Test files associated with this feature. Only valid for feature nodes (leaves).
+
+```yaml
+tests: [auth/login_test.go, auth/session_test.go]
+```
+
+#### `children` (map)
+Nested features. Only valid for boundary nodes. Keys are feature IDs, values are node definitions.
+
+```yaml
+children:
+  login:
+    files: [auth/login.go]
+  logout:
+    files: [auth/logout.go]
+```
+
+### Common Patterns
+
+#### Flat Structure (No Boundaries)
+Simple projects with just features, no nesting:
+
+```yaml
+tree:
+  name: simple-project
+  files: [go.mod]
+  children:
+    config:
+      files: [config.go]
+    server:
+      files: [server.go]
+    handlers:
+      files: [handlers.go]
+```
+
+#### Layered Architecture
+Group by architectural layer:
+
+```yaml
+tree:
+  children:
+    models:                    # Boundary
+      files: [models/interface.go]
+      children:
+        user:
+          files: [models/user.go]
+        account:
+          files: [models/account.go]
+    handlers:                  # Boundary
+      files: [handlers/interface.go]
+      children:
+        auth:
+          files: [handlers/auth.go]
+        api:
+          files: [handlers/api.go]
+```
+
+#### Domain-Driven Design
+Group by business domain:
+
+```yaml
+tree:
+  children:
+    billing:                   # Domain boundary
+      files: [billing/interface.go]
+      children:
+        invoices:
+          files: [billing/invoices.go]
+        payments:
+          files: [billing/payments.go]
+    users:                     # Domain boundary
+      files: [users/interface.go]
+      children:
+        profiles:
+          files: [users/profiles.go]
+        settings:
+          files: [users/settings.go]
+```
+
+#### Deep Nesting
+For complex projects with multiple levels:
+
+```yaml
+tree:
+  children:
+    api:
+      files: [api/interface.go]
+      children:
+        v1:
+          files: [api/v1/interface.go]
+          children:
+            users:
+              files: [api/v1/users.go]
+            posts:
+              files: [api/v1/posts.go]
+```
+
+**When to use deep nesting:**
+- Large projects with clear subdomain divisions
+- API versioning
+- Multi-tenant architectures
+
+**When to avoid:**
+- Creates long feature IDs (`api/v1/admin/users/list`)
+- Makes `feat work` typing harder
+- Consider flatter structure if >3 levels deep
+
+### Validation Rules
+
+`feat validate` checks your manifest for these issues:
+
+#### Required Fields
+- `tree.name` — Must be non-empty string
+- `config.max_files` — Must be positive integer
+- `config.workflow` — Must be non-empty array
+
+#### Node Validation
+- A node cannot have both `children` and `files`/`tests`
+- Feature IDs must be unique within siblings
+- File paths must be non-empty strings
+
+#### Common Errors
+
+**Error:** `node cannot be both boundary and feature`
+```yaml
+# Invalid: has children AND files
+auth:
+  files: [auth.go]           # ❌ Features can't have children
+  children:
+    login: {}
+```
+**Fix:** Move files to a boundary or remove children:
+```yaml
+auth:                        # ✅ Boundary with interface
+  files: [auth/interface.go]
+  children:
+    login:
+      files: [auth/login.go] # ✅ Feature with files only
+```
+
+**Error:** `duplicate feature ID`
+```yaml
+children:
+  auth:
+    files: [auth.go]
+  auth:                      # ❌ Duplicate key
+    files: [other.go]
+```
+**Fix:** Use unique IDs:
+```yaml
+children:
+  auth:
+    files: [auth.go]
+  auth_v2:                   # ✅ Unique ID
+    files: [auth_v2.go]
+```
+
+**Error:** `max_files must be at least 1`
+```yaml
+config:
+  max_files: 0               # ❌ Must be >= 1
+```
+**Fix:** Set to valid positive integer:
+```yaml
+config:
+  max_files: 3               # ✅ Valid
+```
 
 ## Commands
 

--- a/cmd/feat/main.go
+++ b/cmd/feat/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lola-the-lobster/feat/internal/formatter"
 	"github.com/lola-the-lobster/feat/internal/loader"
 	"github.com/lola-the-lobster/feat/internal/manifest"
+	"github.com/lola-the-lobster/feat/internal/add"
 	"github.com/lola-the-lobster/feat/internal/split"
 	"github.com/lola-the-lobster/feat/internal/state"
 	"github.com/lola-the-lobster/feat/internal/tree"
@@ -76,6 +77,10 @@ func main() {
 		if err := runParse(); err != nil {
 			printError(err, exitcodes.ExitGeneralError)
 		}
+	case "add":
+		if err := runAdd(); err != nil {
+			printError(err, exitcodes.ExitGeneralError)
+		}
 	case "split":
 		if err := runSplit(); err != nil {
 			printError(err, exitcodes.ExitGeneralError)
@@ -128,6 +133,7 @@ func printUsage() {
 	fmt.Println("  list              Show feature tree")
 	fmt.Println("  parse             Parse feat.yaml and dump structure")
 	fmt.Println("  split <parent> <name>  Create a new feature")
+	fmt.Println("  add <feature> <file>   Add a file to an existing feature")
 	fmt.Println("  status            Show current feature context")
 	fmt.Println("  transition        Update feature workflow state")
 	fmt.Println("  validate          Check manifest for issues")
@@ -145,9 +151,69 @@ func printUsage() {
 	fmt.Println("  feat list --json             # Show features as JSON")
 	fmt.Println("  feat work auth/login         # Work on auth/login feature")
 	fmt.Println("  feat split auth login-v2     # Create auth/login-v2 feature")
+	fmt.Println("  feat add manifest validate.go # Add file to manifest feature")
 	fmt.Println("  feat status                  # Show current feature")
 	fmt.Println("  feat transition build        # Mark feature as 'build' state")
 	fmt.Println("  feat validate                # Check for issues")
+}
+
+
+func runAdd() error {
+	if len(os.Args) < 4 {
+		return fmt.Errorf("usage: feat add <feature-path> <file-path>\n\nExamples:\n  feat add manifest internal/manifest/validate.go\n  feat add cli cmd/feat/config.go")
+	}
+
+	featurePath := os.Args[2]
+	filePath := os.Args[3]
+
+	fs := flag.NewFlagSet("add", flag.ContinueOnError)
+	var manifestPath string
+	var forceTest bool
+	fs.StringVar(&manifestPath, "f", "feat.yaml", "Path to manifest file")
+	fs.BoolVar(&forceTest, "test", false, "Force treating file as a test file")
+	if err := fs.Parse(os.Args[4:]); err != nil {
+		return err
+	}
+
+	absPath, err := resolveManifestPath(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	m, err := manifest.Load(absPath)
+	if err != nil {
+		return fmt.Errorf("loading manifest: %w", err)
+	}
+
+	result, err := add.Add(m, add.Options{
+		FeaturePath: featurePath,
+		FilePath:    filePath,
+		ManifestDir: filepath.Dir(absPath),
+		ForceTest:   forceTest,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := m.Save(absPath); err != nil {
+		return fmt.Errorf("saving manifest: %w", err)
+	}
+
+	if jsonOutput {
+		output := map[string]interface{}{
+			"feature":   result.FeaturePath,
+			"file":      result.FilePath,
+			"isTest":    result.IsTest,
+			"addedTo":   result.AddedTo,
+			"manifest":  absPath,
+		}
+		data, _ := json.MarshalIndent(output, "", "  ")
+		fmt.Println(string(data))
+	} else {
+		fmt.Print(add.FormatResult(result))
+	}
+
+	return nil
 }
 
 func runInit() error {

--- a/feat.yaml
+++ b/feat.yaml
@@ -1,37 +1,47 @@
 config:
-  max_files: 3
+    max_files: 3
 tree:
-  name: feat
-  files:
-    - go.mod
-    - go.sum
-    - justfile
-  children:
-    cli:
-      files:
-        - cmd/feat/main.go
-    manifest:
-      files:
-        - internal/manifest/manifest.go
-      tests:
-        - internal/manifest/manifest_test.go
-    loader:
-      files:
-        - internal/loader/loader.go
-      tests:
-        - internal/loader/loader_test.go
-    split:
-      files:
-        - internal/split/split.go
-      tests:
-        - internal/split/split_test.go
-    tree:
-      files:
-        - internal/tree/tree.go
-      tests:
-        - internal/tree/tree_test.go
-    state:
-      files:
-        - internal/state/state.go
-      tests:
-        - internal/state/state_test.go
+    name: feat
+    files:
+        - go.mod
+        - go.sum
+        - justfile
+    children:
+        cli:
+            files:
+                - cmd/feat/main.go
+        errors:
+            files:
+                - internal/errors/errors.go
+        formatter:
+            files:
+                - internal/formatter/formatter.go
+            tests:
+                - internal/formatter/formatter_test.go
+        loader:
+            files:
+                - internal/loader/loader.go
+            tests:
+                - internal/loader/loader_test.go
+        manifest:
+            files:
+                - internal/manifest/manifest.go
+                - internal/manifest/validate.go
+            tests:
+                - internal/manifest/manifest_test.go
+                - internal/manifest/validate_test.go
+        split:
+            files:
+                - internal/split/split.go
+            tests:
+                - internal/split/split_test.go
+        state:
+            files:
+                - internal/state/state.go
+            tests:
+                - internal/state/state_test.go
+        tree:
+            files:
+                - internal/tree/tree.go
+            tests:
+                - internal/tree/tree_test.go

--- a/internal/add/add.go
+++ b/internal/add/add.go
@@ -1,0 +1,199 @@
+// Package add handles adding files to existing features in the manifest.
+package add
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lola-the-lobster/feat/internal/manifest"
+)
+
+// Options configures the add operation.
+type Options struct {
+	// FeaturePath is the path to the feature (e.g., "manifest" or "auth/login").
+	FeaturePath string
+
+	// FilePath is the path to the file to add (relative to manifest directory).
+	FilePath string
+
+	// ManifestDir is the directory containing the manifest (for path resolution).
+	ManifestDir string
+
+	// ForceTest forces the file to be treated as a test file.
+	ForceTest bool
+}
+
+// Result contains the outcome of an add operation.
+type Result struct {
+	// FeaturePath is the feature the file was added to.
+	FeaturePath string
+
+	// FilePath is the normalized file path that was added.
+	FilePath string
+
+	// IsTest is true if the file was added as a test file.
+	IsTest bool
+
+	// AddedTo indicates which list the file was added to ("files" or "tests").
+	AddedTo string
+}
+
+// Add adds a file to an existing feature.
+func Add(m *manifest.Manifest, opts Options) (*Result, error) {
+	if opts.FeaturePath == "" {
+		return nil, fmt.Errorf("feature path cannot be empty")
+	}
+	if opts.FilePath == "" {
+		return nil, fmt.Errorf("file path cannot be empty")
+	}
+
+	// Normalize the file path
+	normalizedPath := normalizePath(opts.FilePath)
+
+	// Check if file already exists in any feature
+	if existingFeature := findFileInManifest(m, normalizedPath); existingFeature != "" {
+		return nil, fmt.Errorf("file already exists in feature '%s': %s", existingFeature, normalizedPath)
+	}
+
+	// Navigate to the feature
+	parts := splitPath(opts.FeaturePath)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("invalid feature path: %s", opts.FeaturePath)
+	}
+
+	node, parentMap, nodeName, err := navigateToFeature(m, parts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify it's a feature (has content), not a boundary
+	if !node.IsFeature() && node.Children != nil {
+		return nil, fmt.Errorf("'%s' is a boundary, not a feature. Cannot add files to boundaries", opts.FeaturePath)
+	}
+
+	// Determine if it's a test file using config pattern
+	testPattern := m.Config.GetTestPattern()
+	isTest := opts.ForceTest || isTestFile(normalizedPath, testPattern)
+
+	// Add to appropriate list
+	if isTest {
+		node.Tests = append(node.Tests, normalizedPath)
+	} else {
+		node.Files = append(node.Files, normalizedPath)
+	}
+
+	// Update the node in the parent map
+	parentMap[nodeName] = node
+
+	// Check if file exists on disk (warning only)
+	fullPath := filepath.Join(opts.ManifestDir, normalizedPath)
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		// File doesn't exist yet - this is a warning, not an error
+		// The user might be planning to create it
+	}
+
+	return &Result{
+		FeaturePath: opts.FeaturePath,
+		FilePath:    normalizedPath,
+		IsTest:      isTest,
+		AddedTo:     map[bool]string{true: "tests", false: "files"}[isTest],
+	}, nil
+}
+
+// navigateToFeature navigates to a feature node and returns it along with its parent map.
+func navigateToFeature(m *manifest.Manifest, parts []string) (manifest.Node, map[string]manifest.Node, string, error) {
+	if m.Tree.Children == nil {
+		return manifest.Node{}, nil, "", fmt.Errorf("manifest has no children")
+	}
+
+	current := m.Tree.Children
+	var parentMap map[string]manifest.Node
+	var nodeName string
+
+	for i, part := range parts {
+		node, exists := current[part]
+		if !exists {
+			return manifest.Node{}, nil, "", fmt.Errorf("feature not found: %s", strings.Join(parts[:i+1], "/"))
+		}
+
+		// Last part - this is our target
+		if i == len(parts)-1 {
+			parentMap = current
+			nodeName = part
+			return node, parentMap, nodeName, nil
+		}
+
+		// Not the last part - must be a boundary with children
+		if node.Children == nil {
+			return manifest.Node{}, nil, "", fmt.Errorf("'%s' is a feature, cannot navigate deeper", strings.Join(parts[:i+1], "/"))
+		}
+		current = node.Children
+	}
+
+	return manifest.Node{}, nil, "", fmt.Errorf("feature not found")
+}
+
+// findFileInManifest searches for a file in all features in the manifest.
+func findFileInManifest(m *manifest.Manifest, filePath string) string {
+	var finder func(map[string]manifest.Node) string
+	finder = func(children map[string]manifest.Node) string {
+		for name, node := range children {
+			// Check this node's files
+			for _, f := range node.Files {
+				if f == filePath {
+					return name
+				}
+			}
+			// Check this node's tests
+			for _, t := range node.Tests {
+				if t == filePath {
+					return name
+				}
+			}
+			// Recurse into children
+			if node.Children != nil {
+				if found := finder(node.Children); found != "" {
+					return name + "/" + found
+				}
+			}
+		}
+		return ""
+	}
+
+	return finder(m.Tree.Children)
+}
+
+// isTestFile returns true if the file is a test file (matches the pattern).
+func isTestFile(path, pattern string) bool {
+	return strings.HasSuffix(path, pattern)
+}
+
+// normalizePath cleans up the file path.
+func normalizePath(path string) string {
+	// Remove leading ./ if present
+	path = strings.TrimPrefix(path, "./")
+	// Clean up any double slashes, etc.
+	return filepath.Clean(path)
+}
+
+// splitPath splits a path into parts.
+func splitPath(path string) []string {
+	var parts []string
+	for _, p := range strings.Split(path, "/") {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+// FormatResult returns a human-readable string representation of the result.
+func FormatResult(r *Result) string {
+	var output string
+	output += fmt.Sprintf("Added file to feature '%s':\n", r.FeaturePath)
+	output += fmt.Sprintf("  File: %s\n", r.FilePath)
+	output += fmt.Sprintf("  Type: %s\n", r.AddedTo)
+	return output
+}

--- a/internal/add/add_test.go
+++ b/internal/add/add_test.go
@@ -1,0 +1,347 @@
+package add
+
+import (
+	"testing"
+
+	"github.com/lola-the-lobster/feat/internal/manifest"
+)
+
+func TestAdd(t *testing.T) {
+	// Create a test manifest
+	m := &manifest.Manifest{
+		Tree: manifest.Tree{
+			Name: "test-project",
+			Children: map[string]manifest.Node{
+				"cli": {
+					Files: []string{"cmd/feat/main.go"},
+				},
+				"manifest": {
+					Files: []string{"internal/manifest/manifest.go"},
+					Tests: []string{"internal/manifest/manifest_test.go"},
+				},
+				"auth": {
+					Children: map[string]manifest.Node{
+						"login": {
+							Files: []string{"internal/auth/login.go"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("add file to existing feature", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "manifest",
+			FilePath:    "internal/manifest/validate.go",
+			ManifestDir: "/tmp",
+		}
+
+		result, err := Add(mCopy, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.FeaturePath != "manifest" {
+			t.Errorf("expected feature path 'manifest', got '%s'", result.FeaturePath)
+		}
+		if result.FilePath != "internal/manifest/validate.go" {
+			t.Errorf("expected file path 'internal/manifest/validate.go', got '%s'", result.FilePath)
+		}
+		if result.IsTest {
+			t.Error("expected IsTest to be false")
+		}
+		if result.AddedTo != "files" {
+			t.Errorf("expected AddedTo 'files', got '%s'", result.AddedTo)
+		}
+
+		// Verify manifest was updated
+		if len(mCopy.Tree.Children["manifest"].Files) != 2 {
+			t.Errorf("expected 2 files in manifest feature, got %d", len(mCopy.Tree.Children["manifest"].Files))
+		}
+	})
+
+	t.Run("add test file (auto-detected)", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "manifest",
+			FilePath:    "internal/manifest/validate_test.go",
+			ManifestDir: "/tmp",
+		}
+
+		result, err := Add(mCopy, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !result.IsTest {
+			t.Error("expected IsTest to be true")
+		}
+		if result.AddedTo != "tests" {
+			t.Errorf("expected AddedTo 'tests', got '%s'", result.AddedTo)
+		}
+	})
+
+	t.Run("error when feature doesn't exist", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "nonexistent",
+			FilePath:    "some/file.go",
+			ManifestDir: "/tmp",
+		}
+
+		_, err := Add(mCopy, opts)
+		if err == nil {
+			t.Error("expected error for nonexistent feature")
+		}
+	})
+
+	t.Run("error when file already exists in another feature", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "cli",
+			FilePath:    "cmd/feat/main.go", // Already exists in cli
+			ManifestDir: "/tmp",
+		}
+
+		_, err := Add(mCopy, opts)
+		if err == nil {
+			t.Error("expected error when adding duplicate file")
+		}
+	})
+
+	t.Run("error when adding to boundary", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "auth", // auth is a boundary (has children)
+			FilePath:    "some/file.go",
+			ManifestDir: "/tmp",
+		}
+
+		_, err := Add(mCopy, opts)
+		if err == nil {
+			t.Error("expected error when adding to boundary")
+		}
+	})
+
+	t.Run("add file to nested feature", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "auth/login",
+			FilePath:    "internal/auth/login_test.go",
+			ManifestDir: "/tmp",
+		}
+
+		result, err := Add(mCopy, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.FeaturePath != "auth/login" {
+			t.Errorf("expected feature path 'auth/login', got '%s'", result.FeaturePath)
+		}
+		if !result.IsTest {
+			t.Error("expected IsTest to be true")
+		}
+	})
+
+	t.Run("normalize path", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "cli",
+			FilePath:    "./cmd/feat/newfile.go",
+			ManifestDir: "/tmp",
+		}
+
+		result, err := Add(mCopy, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.FilePath != "cmd/feat/newfile.go" {
+			t.Errorf("expected normalized path 'cmd/feat/newfile.go', got '%s'", result.FilePath)
+		}
+	})
+
+	t.Run("empty feature path", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "",
+			FilePath:    "some/file.go",
+			ManifestDir: "/tmp",
+		}
+
+		_, err := Add(mCopy, opts)
+		if err == nil {
+			t.Error("expected error for empty feature path")
+		}
+	})
+
+	t.Run("empty file path", func(t *testing.T) {
+		mCopy := copyManifest(m)
+		opts := Options{
+			FeaturePath: "cli",
+			FilePath:    "",
+			ManifestDir: "/tmp",
+		}
+
+		_, err := Add(mCopy, opts)
+		if err == nil {
+			t.Error("expected error for empty file path")
+		}
+	})
+}
+
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		path     string
+		pattern  string
+		expected bool
+	}{
+		{"file.go", "_test.go", false},
+		{"file_test.go", "_test.go", true},
+		{"internal/pkg/file_test.go", "_test.go", true},
+		{"_test.go", "_test.go", true},
+		{"test.go", "_test.go", false},
+		{"test_file.go", "_test.go", false},
+		// Custom patterns
+		{"file.spec.js", ".spec.js", true},
+		{"file.js", ".spec.js", false},
+		{"test.py", "test_", false},
+	}
+
+	for _, tc := range tests {
+		result := isTestFile(tc.path, tc.pattern)
+		if result != tc.expected {
+			t.Errorf("isTestFile(%q, %q) = %v, expected %v", tc.path, tc.pattern, result, tc.expected)
+		}
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"./file.go", "file.go"},
+		{"file.go", "file.go"},
+		{"./internal/file.go", "internal/file.go"},
+		{"internal//file.go", "internal/file.go"},
+	}
+
+	for _, tc := range tests {
+		result := normalizePath(tc.input)
+		if result != tc.expected {
+			t.Errorf("normalizePath(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestFindFileInManifest(t *testing.T) {
+	m := &manifest.Manifest{
+		Tree: manifest.Tree{
+			Name: "test",
+			Children: map[string]manifest.Node{
+				"cli": {
+					Files: []string{"cmd/main.go"},
+				},
+				"manifest": {
+					Files: []string{"internal/manifest.go"},
+					Tests: []string{"internal/manifest_test.go"},
+					Children: map[string]manifest.Node{
+						"validate": {
+							Files: []string{"internal/validate.go"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		filePath string
+		expected string
+	}{
+		{"cmd/main.go", "cli"},
+		{"internal/manifest.go", "manifest"},
+		{"internal/manifest_test.go", "manifest"},
+		{"internal/validate.go", "manifest/validate"},
+		{"nonexistent.go", ""},
+	}
+
+	for _, tc := range tests {
+		result := findFileInManifest(m, tc.filePath)
+		if result != tc.expected {
+			t.Errorf("findFileInManifest(%q) = %q, expected %q", tc.filePath, result, tc.expected)
+		}
+	}
+}
+
+// copyManifest creates a deep copy of a manifest for testing.
+func copyManifest(m *manifest.Manifest) *manifest.Manifest {
+	mCopy := &manifest.Manifest{
+		Tree: manifest.Tree{
+			Name:     m.Tree.Name,
+			Files:    append([]string(nil), m.Tree.Files...),
+			Children: make(map[string]manifest.Node),
+		},
+	}
+
+	var copyNode func(manifest.Node) manifest.Node
+	copyNode = func(n manifest.Node) manifest.Node {
+		result := manifest.Node{
+			Files: append([]string(nil), n.Files...),
+			Tests: append([]string(nil), n.Tests...),
+		}
+		if n.Children != nil {
+			result.Children = make(map[string]manifest.Node)
+			for name, child := range n.Children {
+				result.Children[name] = copyNode(child)
+			}
+		}
+		return result
+	}
+
+	for name, child := range m.Tree.Children {
+		mCopy.Tree.Children[name] = copyNode(child)
+	}
+
+	return mCopy
+}
+
+// TestFormatResult verifies the result formatting.
+func TestFormatResult(t *testing.T) {
+	result := &Result{
+		FeaturePath: "manifest",
+		FilePath:    "internal/manifest/validate.go",
+		IsTest:      false,
+		AddedTo:     "files",
+	}
+
+	output := FormatResult(result)
+	if output == "" {
+		t.Error("FormatResult returned empty string")
+	}
+
+	// Check that it contains key information
+	if !contains(output, "manifest") {
+		t.Error("output should contain feature path")
+	}
+	if !contains(output, "validate.go") {
+		t.Error("output should contain file path")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -23,6 +23,9 @@ type Manifest struct {
 	Tree Tree `yaml:"tree"`
 }
 
+// DefaultTestPattern is the default pattern for detecting test files.
+const DefaultTestPattern = "_test.go"
+
 // Config holds project-wide configuration settings.
 type Config struct {
 	// MaxFiles is the maximum number of files (feature + ancestors) to load.
@@ -32,6 +35,10 @@ type Config struct {
 	// Workflow is the list of workflow steps for features.
 	// Default is ["scaffold", "fix", "build", "test", "done"].
 	Workflow []string `yaml:"workflow,omitempty"`
+
+	// TestPattern is the suffix pattern for detecting test files.
+	// Default is "_test.go" for Go projects.
+	TestPattern string `yaml:"test_pattern,omitempty"`
 }
 
 // GetMaxFiles returns the max_files value, or the default if not set.
@@ -48,6 +55,14 @@ func (c Config) GetWorkflow() []string {
 		return DefaultWorkflow
 	}
 	return c.Workflow
+}
+
+// GetTestPattern returns the test file pattern, or the default if not set.
+func (c Config) GetTestPattern() string {
+	if c.TestPattern == "" {
+		return DefaultTestPattern
+	}
+	return c.TestPattern
 }
 
 // Tree represents the root node of the feature hierarchy.


### PR DESCRIPTION
Closes #31

Adds the `feat add` command that allows adding files to existing features without manual YAML editing.

## Usage
```bash
feat add <feature-path> <file-path>
```

## Features
- Auto-detects test files (`_test.go` suffix)
- Prevents duplicate files across features
- Supports nested features (e.g., `auth/login`)
- JSON output with `--json`

## Example
```bash
feat add manifest internal/manifest/validate.go
feat add cli cmd/feat/config.go --test  # force as test file
```